### PR TITLE
Build project with prisma and nextjs

### DIFF
--- a/fernscribe/next-env.d.ts
+++ b/fernscribe/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/fernscribe/src/app/api/exports/[id]/route.ts
+++ b/fernscribe/src/app/api/exports/[id]/route.ts
@@ -28,11 +28,12 @@ export async function POST(req: NextRequest, { params }: Params) {
   }
   if (format === 'docx') {
     const buf = await generateDOCX(transcriptId)
-    return new NextResponse(buf, { headers: { 'Content-Type': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' } })
+    const body = new Uint8Array(buf)
+    return new NextResponse(body, { headers: { 'Content-Type': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' } })
   }
   if (format === 'txt') {
     const t = await getTranscriptData(transcriptId)
-    const base = clean && t.cleanReadId ? t.cleanRead?.text ?? '' : t.segments.map((s) => s.text).join(' ')
+    const base = clean && t.cleanRead ? (t.cleanRead?.text ?? '') : t.segments.map((s) => s.text).join(' ')
     const txt = await generateTXT(transcriptId, base)
     return new NextResponse(txt, { headers: { 'Content-Type': 'text/plain' } })
   }

--- a/fernscribe/src/app/api/transcripts/[id]/cleanread/route.ts
+++ b/fernscribe/src/app/api/transcripts/[id]/cleanread/route.ts
@@ -15,7 +15,7 @@ export async function POST(_req: NextRequest, { params }: Params) {
   const cr = await prisma.cleanRead.upsert({
     where: { transcriptId: t.id },
     update: { text: cleaned },
-    create: { transcript: { connect: { id: t.id } }, transcriptId: t.id, text: cleaned },
+    create: { transcript: { connect: { id: t.id } }, text: cleaned },
   })
   return NextResponse.json({ cleanReadId: cr.id, text: cleaned })
 }

--- a/fernscribe/src/app/api/upload/handle/route.ts
+++ b/fernscribe/src/app/api/upload/handle/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { handleUpload } from '@vercel/blob/client'
+
+export async function POST(req: NextRequest) {
+  const body = await req.json()
+  try {
+    const result = await handleUpload({
+      request: req,
+      body,
+      onBeforeGenerateToken: async (pathname) => {
+        return {
+          access: 'public',
+          addRandomSuffix: true,
+          contentType: undefined,
+          cacheControlMaxAge: 60 * 60 * 24 * 365,
+        }
+      },
+      onUploadCompleted: async () => {
+        // No-op; URL is returned to client which then triggers the transcribe job
+      },
+    })
+
+    if (result.type === 'blob.generate-client-token') {
+      return NextResponse.json({ clientToken: result.clientToken })
+    }
+    return NextResponse.json({ ok: true })
+  } catch (e: any) {
+    return NextResponse.json({ error: e.message || 'Upload handling failed' }, { status: 400 })
+  }
+}

--- a/fernscribe/src/app/api/upload/signed-url/route.ts
+++ b/fernscribe/src/app/api/upload/signed-url/route.ts
@@ -1,8 +1,0 @@
-import { NextRequest, NextResponse } from 'next/server'
-import { generateUploadURL } from '@vercel/blob'
-
-export async function POST(req: NextRequest) {
-  const { filename, contentType } = await req.json()
-  const { url } = await generateUploadURL({ access: 'public', contentType, tokenPayload: { filename } })
-  return NextResponse.json({ url })
-}

--- a/fernscribe/src/lib/assemblyai.ts
+++ b/fernscribe/src/lib/assemblyai.ts
@@ -81,8 +81,8 @@ export async function pollAndIngestTranscript(jobId: string) {
   const transcript = existing ?? (await prisma.transcript.create({ data: { fileId: job.fileId } }))
 
   const speakersMap = new Map<string, string>()
-  const speakers = (transcriptData.utterances || []).map((u: any) => u.speaker || 'Speaker')
-  Array.from(new Set(speakers)).forEach((label, idx) => speakersMap.set(label, `S${idx + 1}`))
+  const speakers = (transcriptData.utterances || []).map((u: any) => u.speaker || 'Speaker') as string[]
+  Array.from(new Set<string>(speakers)).forEach((label, idx) => speakersMap.set(String(label), `S${idx + 1}`))
 
   await prisma.$transaction([
     prisma.segment.deleteMany({ where: { transcriptId: transcript.id } }),

--- a/fernscribe/tsconfig.json
+++ b/fernscribe/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": false,
     "skipLibCheck": true,
     "strict": true,
@@ -15,9 +19,23 @@
     "jsx": "preserve",
     "incremental": true,
     "paths": {
-      "@/*": ["./src/*"]
-    }
+      "@/*": [
+        "./src/*"
+      ]
+    },
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
Updates Vercel Blob API usage, fixes response body typing, and corrects Prisma upsert to resolve build failures.

The build was failing due to three main issues: the `@vercel/blob` API for signed URLs changed in v0.23.x, requiring a switch to the `upload` client-side function with a `handleUpload` server route; `NextResponse` did not accept `Buffer` directly, necessitating conversion to `Uint8Array`; and a Prisma `upsert` operation incorrectly included `transcriptId` in the `create` data when using a `connect` relation.

---
<a href="https://cursor.com/background-agent?bcId=bc-f57e5cb4-30b8-4c86-b0af-12571567d31b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f57e5cb4-30b8-4c86-b0af-12571567d31b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

